### PR TITLE
Update override-decorate-controller.md

### DIFF
--- a/src/content/1.7/modules/concepts/controllers/admin-controllers/override-decorate-controller.md
+++ b/src/content/1.7/modules/concepts/controllers/admin-controllers/override-decorate-controller.md
@@ -159,6 +159,20 @@ However we could modify the input request or the output given by decorated contr
     }
 ```
 
+In order for the DemoController to work, we also need to implement all the other Action methods we don't interfere with of the decorated controller and simply return the decorated controller method. Example:
+
+```php
+<?php
+ public function anAction($id, Request $request)
+        {
+            return $this->decoratedController->anAction($id, $request);
+        }
+
+```
+
+On some edge cases we might need to perform an Ajax call from our Javascript file (or the Twig template) to our decorating DemoController.
+Curently this will not work though, what we need to do in such a case is to create a regular admincontroller e.g. mymodule/src/Controller/Admin/DemoAjaxController.php with a method, create a route for that method in our mymodule/src/config/routes.yml, generate the URL as described here, [symfony docs](https://devdocs.prestashop.com/1.7/modules/concepts/controllers/admin-controllers/route-generation/) and perform our ajax call using the resulting Symfony route.
+
 
 {{% notice tip %}}
 If you have trouble writing the right service configuration for your decoration, you can use Symfony debugger to dump the routes with `php bin/console debug:container`. It can also be helpful to find the service ID of the controller.


### PR DESCRIPTION
Ajax calls not working with decorated controllers; mention to clarify the need of implementing the decorated controller action methods

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop developer documentation! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines on how to contribute:
https://devdocs.prestashop.com/1.7/contribute/documentation/how/
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Found out the ajax calls are not working when calling a decorating controller's method; also clarified the need of implementing the decorated controller action methods
| Fixed ticket? | Fixes #{issue number here} if there is a related issue

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
